### PR TITLE
Adds ability to load key from env variable

### DIFF
--- a/src/keySources/env.js
+++ b/src/keySources/env.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2017 Tom Shawver
+ */
+
+'use strict'
+
+module.exports = () => {
+  return new Promise((resolve, reject) => {
+    if (process.env.CRYPTEX_ENV_KEY) {
+      resolve(process.env.CRYPTEX_ENV_KEY)
+    } else {
+      reject(new Error('CRYPTEX_ENV_KEY not assigned'))
+    }
+  })
+}

--- a/test/src/keySources/env.spec.js
+++ b/test/src/keySources/env.spec.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Tom Shawver
+ */
+
+'use strict'
+
+const getKey = require('src/keySources/env')
+
+describe('Environment Source', () => {
+  it('resolves with the provided key', () => {
+    process.env.CRYPTEX_ENV_KEY = 'bar'
+
+    return getKey().then((key) => {
+      should.exist(key)
+      key.should.equal('bar')
+    })
+  })
+  it('rejects when option "key" is missing', () => {
+    delete process.env.CRYPTEX_ENV_KEY
+    return getKey().should.be.rejected
+  })
+})


### PR DESCRIPTION
This adds the ability to store the encryption key in an environment variable so that it doesn't need to be persisted to a file, etc. The use case for this is for deploying to something like Heroku. 

It stores the key in the `CRYPTEX_ENV_KEY`. Happy to change that name to something that would make more sense.

